### PR TITLE
Add actions to Auth0 class

### DIFF
--- a/auth0/v3/management/auth0.py
+++ b/auth0/v3/management/auth0.py
@@ -1,3 +1,4 @@
+from .actions import Actions
 from .blacklists import Blacklists
 from .client_grants import ClientGrants
 from .clients import Clients
@@ -41,6 +42,7 @@ class Auth0(object):
     """
 
     def __init__(self, domain, token, rest_options=None):
+        self.actions = Actions(domain=domain, token=token, rest_options=rest_options)
         self.blacklists = Blacklists(domain=domain, token=token, rest_options=rest_options)
         self.client_grants = ClientGrants(domain=domain, token=token, rest_options=rest_options)
         self.clients = Clients(domain=domain, token=token, rest_options=rest_options)

--- a/auth0/v3/test/management/test_auth0.py
+++ b/auth0/v3/test/management/test_auth0.py
@@ -1,6 +1,7 @@
 import unittest
 
 from ...management.auth0 import Auth0
+from ...management.actions import Actions
 from ...management.blacklists import Blacklists
 from ...management.client_grants import ClientGrants
 from ...management.clients import Clients
@@ -34,6 +35,9 @@ class TestAuth0(unittest.TestCase):
         self.domain = "user.some.domain"
         self.token = "a-token"
         self.a0 = Auth0(self.domain, self.token)
+
+    def test_blacklists(self):
+        self.assertIsInstance(self.a0.actions, Actions)
 
     def test_blacklists(self):
         self.assertIsInstance(self.a0.blacklists, Blacklists)


### PR DESCRIPTION
### Changes

Solving https://github.com/auth0/auth0-python/issues/292

Added actions class property to management Auth0 class

### References

Please include relevant links supporting this change such as a:

- support ticket

https://github.com/auth0/auth0-python/issues/292

### Testing

from auth0.v3.management import Auth0
tenant_domain = ""
mgmt_api_token = ""
auth0 = Auth0(tenant_domain, mgmt_api_token)
action = auth0.actions.get_actions()

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
